### PR TITLE
Add terraform testing/onboarding files

### DIFF
--- a/Teams_T2_2022/Cloud_Dev/onboarding/examples/terraform_test/main.tf
+++ b/Teams_T2_2022/Cloud_Dev/onboarding/examples/terraform_test/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "4.30.0"
+    }
+  }
+}
+
+provider "google" {
+  project = "sit-22t2-breaking-capt-8718903"
+  region = "australia-southeast2"
+}
+
+resource "google_storage_bucket" "test-bucket" {
+  name          = "jets_test_bucket"
+  location      = "US"
+  force_destroy = true
+}


### PR DESCRIPTION
Adding 2 new directories
- onboarding
- terraform_test

These will be apart of the onboarding process for the cloud development team. Where they will pull the file and test is their terraform is setup correctly.